### PR TITLE
Add JWS token verification for user authentication

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -35,3 +35,6 @@ ssl_basepath = /etc/letsencrypt/live/remote.schunterkino.de
 ssl_certificate_file = cert.pem
 # File containing the private key for the certificate.
 ssl_privatekey_file = privkey.pem
+
+# Secret key for signing JSON Web Tokens. MUST be the same as the in the PHP file.
+jws_signature_key = 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
 			<artifactId>purejavacomm</artifactId>
 			<version>1.0.2.RELEASE</version>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.8.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<dependency>
 			<groupId>org.java-websocket</groupId>
 			<artifactId>Java-WebSocket</artifactId>
-			<version>1.3.4</version>
+			<version>1.3.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/src/main/java/de/schunterkino/kinoapi/websocket/CinemaWebSocketServer.java
+++ b/src/main/java/de/schunterkino/kinoapi/websocket/CinemaWebSocketServer.java
@@ -69,6 +69,7 @@ import de.schunterkino.kinoapi.websocket.messages.volume.MuteStatusChangedMessag
 import de.schunterkino.kinoapi.websocket.messages.volume.PowerModeChangedMessage;
 import de.schunterkino.kinoapi.websocket.messages.volume.VolumeChangedMessage;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.impl.TextCodec;
 
 /**
  * WebSocket server class which serves the documented JSON API. This class acts
@@ -205,7 +206,8 @@ public class CinemaWebSocketServer extends WebSocketServer
 		// because.
 		try {
 			Jwts.parser().requireSubject("SchunterKinoRemote")
-					.setSigningKey(App.getConfigurationString("jws_signature_key")).parseClaimsJws(compactJws);
+					.setSigningKey(TextCodec.BASE64.decode(App.getConfigurationString("jws_signature_key")))
+					.parseClaimsJws(compactJws);
 		} catch (Exception e) {
 			System.err.println(e.getMessage());
 			e.printStackTrace();


### PR DESCRIPTION
Try to extract a token from the `token` cookie, which is sent by the browser during the websocket handshake upgrade request.
The token is generated by the kinoapi-token PHP script when the user provides the correct password.

The connection is closed again if the token is missing or invalid/malformed.